### PR TITLE
Use ~ to install node-mapnik

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test:watch": "npm run test -- -w"
   },
   "dependencies": {
-    "mapnik": "^3.6.2"
+    "mapnik": "~3.6.2"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",


### PR DESCRIPTION
This will protect your module from automatically upgrading to node-mapnik v3.7.0 (when it is published). This in turn will protect your users from breakages if they are running windows.

Refs mapnik/node-mapnik#848