### PR TITLE
Use new getTile interface with promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## v0.8.0 (2020-mm-dd)
 
-- Normalize getTile(), now returns an object with buffer property, it renames `tile` by `buffer`
+- Normalize `renderer.getTile()`, now returns an object with buffer property, it renames `tile` by `buffer`
+- Add `renderer.getStats()` to get information about the renderer's performance
 
 ## v0.7.0 (2019-07-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Cartonik ChangeLog
 
+## v0.8.0 (2020-mm-dd)
+
+- Normalize getTile(), now returns an object with buffer property, it renames `tile` by `buffer`
+
 ## v0.7.0 (2019-07-30)
 
 - Preview: add option `concurrency` to avoid map-pool exhaustion in renderer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Normalize `renderer.getTile()`, now returns an object with buffer property, it renames `tile` by `buffer`
 - Add `renderer.getStats()` to get information about the renderer's performance
+- Add new metric: remaining renderers to be acquired by the internal pool
 
 ## v0.7.0 (2019-07-30)
 

--- a/README.md
+++ b/README.md
@@ -82,15 +82,12 @@ const { image } = await preview({
         width: 200,
         height: 200
     },
-    getTile: function (x, y, z, callback) {
-        renderer.getTile('png', z, x, y)
-            .then(({ tile }) => callback(null, tile))
-            .catch((err) => callback(err))
+    getTile: async function (format, x, y, z) {
+        const { buffer } = await renderer.getTile(format, z, x, y)
+        return { buffer }
     }
 })
 ```
-
-**Note**: Preview implementes old getTile interface: `renderer.getTile(z, x, y, callback)`; this is going to change soon. The new interface is: `const tile = await renderer.getTile(format, z, x, y)`
 
 ## :computer: Usage: `preview(options)`
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install @carto/cartonik
 ## :globe_with_meridians: Render tiles
 
 ```js
-const { rendererFactory } = require('cartonik')
+const { rendererFactory } = require('@carto/cartonik')
 
 const renderer = rendererFactory({ xml: '<Map>...</Map>' })
 const [ format, z, x, y ] = [ 'png', 0, 0, 0 ]
@@ -38,24 +38,11 @@ const options = { ... }
 const renderer = rendererFactory(options)
 ```
 
-## :mag: Get information about the renderer
-
-```js
-const { rendererFactory } = require('cartonik')
-
-const renderer = rendererFactory({ xml: '<Map>...</Map>' })
-
-const stats = renderer.getStats()
-
-console.log(stats)
-//  Map { 'cache.png' => 1, 'pool.count' => 2, 'pool.used' => 1, 'pool.unused' => 1, 'pool.waiting' => 0 }
-```
-
 ## :triangular_ruler: Renderer options
 
 - `type`: `string` (either `raster` or `vector`, default `raster`). Whether the renderer aims to render Mapnik Vector Tiles or traditional raster formats (`png`, `utf`).
 - `xml`: `string` (*required*). The [Mapnik XML](https://github.com/mapnik/mapnik/wiki/XMLConfigReference) configuration.
-- `base`: `string`. Path to the folder where the datasources files are (e.g. shapefiles).
+- `base`: `string`. Path to the folder where the datasource files are (e.g. shapefiles).
 - `strict`: `boolean` (default `false`). Enables mapnik strict mode.
 - `bufferSize`: `number` (default `256`). Extra space, in pixels, surrounding the map size being rendered. This allows you to have text and symbols rendered correctly when they overlap the image boundary.
 - `poolSize`: `number` (default `os.cpus().length`). Max number of preloaded maps available for rendering.
@@ -79,10 +66,23 @@ console.log(stats)
 
 - `gzip`: `boolean` (default `true`). Compression method used to encoding a vector tile.
 
+## :mag: Get information about the renderer
+
+```js
+const { rendererFactory } = require('@carto/cartonik')
+
+const renderer = rendererFactory({ xml: '<Map>...</Map>' })
+
+const stats = renderer.getStats()
+
+console.log(stats)
+//  Map { 'cache.png' => 1, 'pool.count' => 2, 'pool.used' => 1, 'pool.unused' => 1, 'pool.waiting' => 0 }
+```
+
 ## :fireworks: Static images (previews)
 
 ```js
-const { preview, rendererFactory } = require('cartonik')
+const { preview, rendererFactory } = require('@carto/cartonik')
 
 const renderer = rendererFactory({ xml: '<Map>...</Map>' })
 
@@ -135,9 +135,10 @@ const renderer = preview(options)
 
 We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/cartodb/cartonik/tags).
 
-## :busts_in_silhouette: Authors
+## :busts_in_silhouette: Contributors
 
 - [Daniel García Aubert](https://github.com/dgaubert)
+- [Raúl Marín](https://github.com/Algunenano)
 
 ## :page_with_curl: License
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,19 @@ const options = { ... }
 const renderer = rendererFactory(options)
 ```
 
+## :mag: Get information about the renderer
+
+```js
+const { rendererFactory } = require('cartonik')
+
+const renderer = rendererFactory({ xml: '<Map>...</Map>' })
+
+const stats = renderer.getStats()
+
+console.log(stats)
+//  Map { 'cache.png' => 1, 'pool.count' => 2, 'pool.used' => 1, 'pool.unused' => 1, 'pool.waiting' => 0 }
+```
+
 ## :triangular_ruler: Renderer options
 
 - `type`: `string` (either `raster` or `vector`, default `raster`). Whether the renderer aims to render Mapnik Vector Tiles or traditional raster formats (`png`, `utf`).

--- a/lib/preview/blend.js
+++ b/lib/preview/blend.js
@@ -47,7 +47,7 @@ function getCoordinateBatches ({ coordinates, concurrency }) {
 
 function getTiles ({ coordinates, format, getTile }) {
   return coordinates.map(({ z, x, y }) => getTile(format, z, x, y)
-    .then(({ tile: buffer, stats = {} }) => ({ buffer, stats })))
+    .then(({ buffer, stats = {} }) => ({ buffer, stats })))
 }
 
 function calculateStats ({ tiles }) {

--- a/lib/preview/blend.js
+++ b/lib/preview/blend.js
@@ -4,7 +4,7 @@ const { promisify } = require('util')
 const blend = promisify(require('@carto/mapnik').blend)
 
 module.exports = async function blend ({ coordinates, offsets, dimensions, format, quality, getTile, concurrency }) {
-  const tiles = await getTilesInBatches({ coordinates, getTile, concurrency })
+  const tiles = await getTilesInBatches({ coordinates, format, getTile, concurrency })
 
   if (!tiles || !tiles.length) {
     throw new Error('No tiles to stitch')
@@ -16,12 +16,12 @@ module.exports = async function blend ({ coordinates, offsets, dimensions, forma
   return { image, stats }
 }
 
-async function getTilesInBatches ({ coordinates, getTile, concurrency }) {
+async function getTilesInBatches ({ coordinates, format, getTile, concurrency }) {
   const batches = getCoordinateBatches({ coordinates, concurrency })
   const tiles = []
 
   for (const coords of batches) {
-    tiles.push(...await Promise.all(getTiles({ coordinates: coords, getTile })))
+    tiles.push(...await Promise.all(getTiles({ coordinates: coords, format, getTile })))
   }
 
   return tiles
@@ -45,11 +45,9 @@ function getCoordinateBatches ({ coordinates, concurrency }) {
   return batches
 }
 
-function getTiles ({ coordinates, getTile }) {
-  const getTilePromisified = promisify(getTile)
-
-  return coordinates.map(({ z, x, y }) => getTilePromisified(z, x, y)
-    .then((tile, headers, stats = {}) => ({ buffer: tile, stats })))
+function getTiles ({ coordinates, format, getTile }) {
+  return coordinates.map(({ z, x, y }) => getTile(format, z, x, y)
+    .then(({ tile: buffer, stats = {} }) => ({ buffer, stats })))
 }
 
 function calculateStats ({ tiles }) {

--- a/lib/preview/index.js
+++ b/lib/preview/index.js
@@ -9,7 +9,7 @@ const blend = require('./blend')
 
 module.exports = async function preview (options) {
   const {
-    getTile, // cartonik's getTile(z, x, y) function
+    getTile, // getTile(format, z, x, y) -> Promise<{ buffer }|Error>
     bbox,
     center, dimensions,
     tileSize, scale, format, quality, // render options

--- a/lib/renderer/raster-renderer.js
+++ b/lib/renderer/raster-renderer.js
@@ -106,11 +106,11 @@ class RasterRenderer {
   }
 
   getStats () {
-    const { size: count, borrowed: used, available: unused, pending: waiting } = this._mapPool
-    const pool = { count, used, unused, waiting }
+    const { size: count, borrowed: used, available: unused, pending: waiting, spareResourceCapacity: remaining } = this._mapPool
+    const pool = { count, used, unused, waiting, remaining }
     const cacheResults = this._metatileCache.results || {}
     const cache = Object.keys(cacheResults).reduce((cacheStats, key) => {
-      const [ format, ...coords ] = key.split(',') // eslint-disable-line no-unused-vars
+      const [ format ] = key.split(',')
 
       if (!cacheStats[format]) {
         cacheStats[format] = 0

--- a/lib/renderer/raster-renderer.js
+++ b/lib/renderer/raster-renderer.js
@@ -121,11 +121,11 @@ async function sliceMetatile (coords, map, image, options, metatile, stats) {
   }
 
   const encode = promisify(view.encode.bind(view))
-  const tile = await encode(...params)
+  const buffer = await encode(...params)
 
   return {
     [key]: {
-      tile,
+      buffer,
       headers: headers(options.format),
       stats: Object.assign(stats, { encode: Date.now() - encodeStartTime }, image.get_metrics())
     }

--- a/lib/renderer/raster-renderer.js
+++ b/lib/renderer/raster-renderer.js
@@ -104,6 +104,33 @@ class RasterRenderer {
       this._mapPool.release(map)
     }
   }
+
+  getStats () {
+    const { size: count, borrowed: used, available: unused, pending: waiting } = this._mapPool
+    const pool = { count, used, unused, waiting }
+    const cacheResults = this._metatileCache.results || {}
+    const cache = Object.keys(cacheResults).reduce((cacheStats, key) => {
+      const [ format, ...coords ] = key.split(',') // eslint-disable-line no-unused-vars
+
+      if (!cacheStats[format]) {
+        cacheStats[format] = 0
+      }
+
+      cacheStats[format] += 1
+
+      return cacheStats
+    }, {})
+
+    const stats = new Map()
+
+    for (const [name, resource] of Object.entries({ pool, cache })) {
+      for (const [stat, value] of Object.entries(resource)) {
+        stats.set(`${name}.${stat}`, value)
+      }
+    }
+
+    return stats
+  }
 }
 
 async function sliceMetatile (coords, map, image, options, metatile, stats) {

--- a/lib/renderer/vector-renderer.js
+++ b/lib/renderer/vector-renderer.js
@@ -88,6 +88,17 @@ class VectorRenderer {
       this._mapPool.release(map)
     }
   }
+
+  getStats () {
+    const { size: count, borrowed: used, available: unused, pending: waiting } = this._mapPool
+    const stats = new Map()
+
+    for (const [stat, value] of Object.entries({ count, used, unused, waiting })) {
+      stats.set(`pool.${stat}`, value)
+    }
+
+    return stats
+  }
 }
 
 // We (CARTO) are using always the default value: deferred = 2;

--- a/lib/renderer/vector-renderer.js
+++ b/lib/renderer/vector-renderer.js
@@ -71,7 +71,7 @@ class VectorRenderer {
       headers['x-tilelive-contains-data'] = vtile.painted()
 
       if (vtile.empty()) {
-        return { tile: Buffer.alloc(0), headers }
+        return { buffer: Buffer.alloc(0), headers }
       }
 
       const encode = promisify(tile.getData.bind(tile))
@@ -81,7 +81,7 @@ class VectorRenderer {
         headers['Content-Encoding'] = 'gzip'
       }
 
-      return { tile: data, headers }
+      return { buffer: data, headers }
     } catch (err) {
       throw err
     } finally {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cartonik",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carto/cartonik",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Render maps with @carto/mapnik",
   "publishConfig": {
     "access": "public"
@@ -8,7 +8,8 @@
   "main": "lib/cartonik.js",
   "author": "CARTO (https://carto.com/)",
   "contributors": [
-    "Daniel García Aubert <dgaubert@carto.com>"
+    "Daniel García Aubert <dgaubert@carto.com>",
+    "Raúl Marín <rmrodriguez@carto.com>"
   ],
   "license": "BSD-3-Clause",
   "repository": {

--- a/test/pool-render-test.js
+++ b/test/pool-render-test.js
@@ -57,7 +57,7 @@ describe('pool render ', function () {
         }
 
         if (results.length === tileCoords.length) {
-          const errs = results.filter((err) => err.message === 'max waitingClients count exceeded')
+          const errs = results.filter((err) => err && err.message === 'max waitingClients count exceeded')
           assert.ok(errs.length > 0)
         }
       })

--- a/test/preview.js
+++ b/test/preview.js
@@ -41,12 +41,14 @@ async function getFixtureTiles () {
 }
 
 function getTileFixture ({ tiles, size }) {
-  return function getTile (z, x, y, callback) {
+  return async function getTile (format, z, x, y) {
     const key = [z, x, y, size].join('.')
 
-    return !tiles[key]
-      ? callback(new Error(`Tile ${key} does not exist`))
-      : callback(null, tiles[key])
+    if (!tiles[key]) {
+      throw new Error(`Tile ${key} does not exist`)
+    }
+
+    return { tile: tiles[key] }
   }
 }
 
@@ -515,11 +517,7 @@ describe('preview', function () {
         format: 'png',
         quality: 50,
         tileSize: 256,
-        getTile: function (z, x, y, callback) {
-          renderer.getTile('png', z, x, y)
-            .then(({ tile }) => callback(null, tile))
-            .catch((err) => callback(err))
-        }
+        getTile: renderer.getTile.bind(renderer)
       }
 
       const { image } = await preview(params)
@@ -546,11 +544,7 @@ describe('preview', function () {
         format: 'png',
         quality: 50,
         tileSize: 256,
-        getTile: function (z, x, y, callback) {
-          renderer.getTile('png', z, x, y)
-            .then(({ tile }) => callback(null, tile))
-            .catch((err) => callback(err))
-        }
+        getTile: renderer.getTile.bind(renderer)
       }
 
       const { image } = await preview(params)
@@ -573,11 +567,7 @@ describe('preview', function () {
         format: 'png',
         quality: 50,
         tileSize: 256,
-        getTile: function (z, x, y, callback) {
-          renderer.getTile('png', z, x, y)
-            .then(({ tile }) => callback(null, tile))
-            .catch((err) => callback(err))
-        }
+        getTile: renderer.getTile.bind(renderer)
       }
 
       const { image } = await preview(params)

--- a/test/preview.js
+++ b/test/preview.js
@@ -48,7 +48,7 @@ function getTileFixture ({ tiles, size }) {
       throw new Error(`Tile ${key} does not exist`)
     }
 
-    return { tile: tiles[key] }
+    return { buffer: tiles[key] }
   }
 }
 

--- a/test/render-raster-test.js
+++ b/test/render-raster-test.js
@@ -93,7 +93,9 @@ describe('render raster tiles', function () {
     })
 
     after(async function () {
+      assert.strictEqual(1, renderer.getStats().get('pool.count'))
       await renderer.close()
+      assert.strictEqual(0, renderer.getStats().get('pool.count'))
     })
 
     for (const coords of tileCoords) {
@@ -191,17 +193,90 @@ describe('render raster tiles', function () {
     })
   })
 
-  it('works with metatiles, tile 2/2/2', async function () {
-    const options = Object.assign({}, rendererOptions, {
-      metatile: 4,
-      metrics: true
+  describe('metatiling', function () {
+    const metatileConfig = [
+      {
+        coords: [2, 2, 2],
+        config: {
+          metatile: 4, // at zoom 2 it will query all tiles: 2,0,0 => 2,3,3 (4^2 = 16 tiles)
+          metrics: true,
+          metatileCache: {
+            ttl: 1000,
+            deleteOnHit: false
+          }
+        },
+        deleteOnHit: false, // ttl: 1000, deleteOnHit: false
+        expects: {
+          'pool.count': 1,
+          'cache.png': 16 // deleteOnHit: false
+        }
+      },
+      {
+        coords: [2, 0, 0],
+        config: {
+          metatile: 2,
+          metrics: true,
+          metatileCache: {
+            ttl: 1000,
+            deleteOnHit: false
+          }
+        },
+        deleteOnHit: false,
+        expects: {
+          'pool.count': 1,
+          'cache.png': 4 // ttl: 1000, deleteOnHit: false
+        }
+      },
+      {
+        coords: [2, 0, 2],
+        config: {
+          metatile: 4, // at zoom 2 it will query all tiles: 2,0,0 => 2,3,3 (4^2 = 16 tiles)
+          metrics: true,
+          metatileCache: {
+            ttl: 0,
+            deleteOnHit: false
+          }
+        },
+        deleteOnHit: true, // ttl: 0 (no ttl), deleteOnHit: false
+        expects: {
+          'pool.count': 1,
+          'cache.png': 15 // deleteOnHit: true
+        }
+      },
+      {
+        coords: [2, 1, 0],
+        config: {
+          metatile: 2,
+          metrics: true,
+          metatileCache: {
+            ttl: 1000,
+            deleteOnHit: true
+          }
+        },
+        deleteOnHit: true,
+        expects: {
+          'pool.count': 1,
+          'cache.png': 3 // ttl: 1000, deleteOnHit: true
+        }
+      }
+
+    ]
+
+    metatileConfig.forEach(function ({ coords, config, expects, deleteOnHit }) {
+      it(`should get tile ${coords.join('/')} along ${Math.pow(config.metatile, 2)} metatiles and deleteOnHit ${deleteOnHit ? 'activated' : 'deactivated'}`, async function () {
+        const options = Object.assign({}, rendererOptions, config)
+
+        const renderer = rendererFactory(options)
+        const { stats } = await renderer.getTile('png', 2, 2, 2)
+
+        assert.ok(stats.hasOwnProperty('Mapnik'))
+
+        assert.strictEqual(expects['pool.count'], renderer.getStats().get('pool.count'))
+        assert.strictEqual(expects['cache.png'], renderer.getStats().get('cache.png'))
+        await renderer.close()
+        assert.strictEqual(0, renderer.getStats().get('pool.count'))
+        assert.strictEqual(undefined, renderer.getStats().get('cache.png'))
+      })
     })
-
-    const renderer = rendererFactory(options)
-    const { stats } = await renderer.getTile('png', 2, 2, 2)
-
-    assert.ok(stats.hasOwnProperty('Mapnik'))
-
-    await renderer.close()
   })
 })

--- a/test/render-raster-test.js
+++ b/test/render-raster-test.js
@@ -20,7 +20,7 @@ describe('render raster tiles', function () {
 
     const renderer = rendererFactory(options)
 
-    const { tile, headers, stats } = await renderer.getTile('jpeg:quality=20', 0, 0, 0)
+    const { buffer: tile, headers, stats } = await renderer.getTile('jpeg:quality=20', 0, 0, 0)
 
     assert.ok(stats)
     assert.ok(stats.hasOwnProperty('render'))
@@ -38,7 +38,7 @@ describe('render raster tiles', function () {
 
     const renderer = rendererFactory(options)
 
-    const { tile, headers } = await renderer.getTile('png', 31, 0, 0)
+    const { buffer: tile, headers } = await renderer.getTile('png', 31, 0, 0)
 
     assert.strictEqual(headers['Content-Type'], 'image/png')
     await assert.imageEqualsFile(tile, './test/fixtures/output/pngs/zoom-31.png')
@@ -53,7 +53,7 @@ describe('render raster tiles', function () {
       base: './test/fixtures/datasources/shapefiles/world-borders/'
     })
 
-    const { tile, headers } = await renderer.getTile('utf', 31, 0, 0)
+    const { buffer: tile, headers } = await renderer.getTile('utf', 31, 0, 0)
 
     assert.deepStrictEqual(tile, JSON.parse(fs.readFileSync('./test/fixtures/output/grids/world-borders-interactivity-31.0.0.grid.json', 'utf8')))
     assert.strictEqual(headers['Content-Type'], 'application/json')
@@ -98,7 +98,7 @@ describe('render raster tiles', function () {
 
     for (const coords of tileCoords) {
       it(`tile ${coords.join('/')}`, async function () {
-        const { tile, headers } = await renderer.getTile('png', ...coords)
+        const { buffer: tile, headers } = await renderer.getTile('png', ...coords)
 
         const filepath = `./test/fixtures/output/pngs/world-borders-${coords.join('.')}.png`
         await assert.imageEqualsFile(tile, filepath)
@@ -128,7 +128,7 @@ describe('render raster tiles', function () {
 
     for (const coords of tileCoords) {
       it(`tile ${coords.join('/')}`, async function () {
-        const { tile, headers } = await renderer.getTile('png', ...coords)
+        const { buffer: tile, headers } = await renderer.getTile('png', ...coords)
 
         assert.strictEqual(headers['Content-Type'], 'image/png')
 
@@ -155,7 +155,7 @@ describe('render raster tiles', function () {
 
     for (const coords of tileCoords) {
       it(`tile ${coords.join('/')}, format: grid.json`, async function () {
-        const { tile, headers, stats } = await renderer.getTile('utf', ...coords)
+        const { buffer: tile, headers, stats } = await renderer.getTile('utf', ...coords)
 
         assert.ok(stats)
         assert.ok(stats.hasOwnProperty('render'))
@@ -181,7 +181,7 @@ describe('render raster tiles', function () {
 
         const renderer = rendererFactory(options)
 
-        const { tile, headers } = await renderer.getTile('png', 2, 2, 2)
+        const { buffer: tile, headers } = await renderer.getTile('png', 2, 2, 2)
         await assert.imageEqualsFile(tile, `./test/fixtures/output/pngs/world-borders-custom-color-2.2.2-${customColor}.png`)
 
         assert.strictEqual(headers['Content-Type'], 'image/png')

--- a/test/render-vector-test.js
+++ b/test/render-vector-test.js
@@ -168,7 +168,7 @@ describe('render vector tiles', function () {
 
     it(description, async function () {
       const [ z, x, y ] = coords
-      const { tile, headers } = await renderer.getTile('mvt', ...coords)
+      const { buffer: tile, headers } = await renderer.getTile('mvt', ...coords)
 
       if (empty) {
         assert.strictEqual(tile.length, 0)

--- a/test/render-vector-test.js
+++ b/test/render-vector-test.js
@@ -192,9 +192,9 @@ describe('render vector tiles', function () {
       assert.strictEqual(expectedBuffer.length, buffer.length)
       assert.deepStrictEqual(expectedBuffer, buffer)
 
-      assert.strictEqual(1, renderer._mapPool.size)
+      assert.strictEqual(1, renderer.getStats().get('pool.count'))
       await renderer.close()
-      assert.strictEqual(0, renderer._mapPool.size)
+      assert.strictEqual(0, renderer.getStats().get('pool.count'))
     })
   })
 })

--- a/test/timeout-test.js
+++ b/test/timeout-test.js
@@ -35,7 +35,7 @@ describe('timeout', function () {
       const opts = Object.assign({}, rendererOptions, { limits: { render: 0 } })
 
       const renderer = rendererFactory(opts)
-      const { tile, headers } = await renderer.getTile('png', 0, 0, 0)
+      const { buffer: tile, headers } = await renderer.getTile('png', 0, 0, 0)
 
       assert.ok(tile)
       assert.ok(headers)
@@ -64,7 +64,7 @@ describe('timeout', function () {
       const opts = Object.assign({}, rendererOptions, { limits: { render: 0 } })
 
       const renderer = rendererFactory(opts)
-      const { tile, headers } = await renderer.getTile('mvt', 0, 0, 0)
+      const { buffer: tile, headers } = await renderer.getTile('mvt', 0, 0, 0)
 
       assert.ok(tile)
       assert.ok(headers)


### PR DESCRIPTION
- Normalize `renderer.getTile()`, now returns an object with buffer property, it renames `tile` by `buffer`. See #16
- Add `renderer.getStats()` to get information about the renderer's performance
- Add new metric: remaining renderers to be acquired by the internal pool
